### PR TITLE
Allow splitting by words, and using initials on the words

### DIFF
--- a/__test__/Initial.spec.js
+++ b/__test__/Initial.spec.js
@@ -5,7 +5,7 @@ import Initial from '../src/Initial'
 // https://medium.freecodecamp.org/the-right-way-to-test-react-components-548a4736ab22
 test('check rendered component and create snapshot', () => {
   const component = renderer.create(
-    <Initial name='Bruno Carvalho de Araujo' />
+    <Initial name='Varshneya Rao' charCount={3} width={150} useWords={true} />
   )
 
   let tree = component.toJSON()
@@ -14,6 +14,7 @@ test('check rendered component and create snapshot', () => {
   expect(tree.props.alt).toEqual('')
   expect(tree.props.children).toEqual(undefined)
   expect(typeof tree.props.src).toBe('string')
+  console.log(tree.props.src);
 
   expect(tree).toMatchSnapshot()
 })

--- a/src/Initial.js
+++ b/src/Initial.js
@@ -106,17 +106,24 @@ export default class Initial extends Component<Props> {
     let nextSpace = -1
     let length = string.length
 
+    // Remove any leading/trailing spaces
+    string = string.trim()
+
     while (stringIndex < length) {
-      // Find the next space offset from the previous finding
-      nextSpace = words ? string.indexOf(' ', nextSpace) : -1
-      character = this.unicodeCharAt(string, nextSpace >= 0 ? nextSpace + 1 : stringIndex)
+      character = this.unicodeCharAt(string, stringIndex)
 
       if (unicodeIndex >= start && unicodeIndex < end) {
         accumulator += character
+      } else {
+        break;
       }
 
       stringIndex += character.length
       unicodeIndex += 1
+
+      // Find the next space offset from the previous finding
+      nextSpace = words ? string.indexOf(' ', nextSpace + 1) : -1
+      stringIndex = nextSpace > 0 ? nextSpace + 1 : stringIndex
     }
 
     return accumulator

--- a/src/Initial.js
+++ b/src/Initial.js
@@ -48,7 +48,8 @@ type Props = {
   fontSize?: number,
   fontWeight?: number,
   fontFamily?: string,
-  radius?: number
+  radius?: number,
+  useWords?: boolean
 }
 
 export default class Initial extends Component<Props> {
@@ -97,15 +98,18 @@ export default class Initial extends Component<Props> {
     return string[ index ]
   }
 
-  unicodeSlice (string: string, start: number, end: number): string {
+  unicodeSlice (string: string, start: number, end: number, words: boolean): string {
     let accumulator = ''
     let character
     let stringIndex = 0
     let unicodeIndex = 0
+    let nextSpace = -1
     let length = string.length
 
     while (stringIndex < length) {
-      character = this.unicodeCharAt(string, stringIndex)
+      // Find the next space offset from the previous finding
+      nextSpace = words ? string.indexOf(' ', nextSpace) : -1
+      character = this.unicodeCharAt(string, nextSpace >= 0 ? nextSpace + 1 : stringIndex)
 
       if (unicodeIndex >= start && unicodeIndex < end) {
         accumulator += character
@@ -120,7 +124,7 @@ export default class Initial extends Component<Props> {
 
   render () {
     const { width, height, textColor, fontFamily, fontSize, fontWeight, radius: borderRadius, ...ownProps } = this.props
-    const initial = this.unicodeSlice(this.props.name || 'Name', 0, this.props.charCount || 1).toUpperCase()
+    const initial = this.unicodeSlice(this.props.name || 'Name', 0, this.props.charCount || 1, this.props.useWords || false).toUpperCase()
     const backgroundColor = this.props.color !== null
       ? this.props.color
       : colors[ Math.floor((initial.charCodeAt(0) + this.props.seed) % colors.length) ]


### PR DESCRIPTION
- This change introduces a new props: `useWords`
- When `useWords={true}` we use `charCount` number of characters while splitting the words over spaces
- The original behaviour of using the next char is maintained, if no spaces are found
- This means `name='Bruno Carvalho De Raujo'` with `allowWords={true}` and `charCount={3}` will return `BCD`, while with `charCount={5}` will return `BCDRA` (the A comes from the second char in `Raujo`)